### PR TITLE
[Fix] #60 - 앱 삭제 시 userId 동기화되지 않는 문제 해결

### DIFF
--- a/DPlay-iOS/DPlay-iOS/App/Coordinator/AuthFlowCoordinator.swift
+++ b/DPlay-iOS/DPlay-iOS/App/Coordinator/AuthFlowCoordinator.swift
@@ -28,7 +28,7 @@ final class AuthFlowCoordinator: Coordinator {
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             
-            if KeychainManager.shared.accessToken != nil {
+            if KeychainManager.shared.accessToken != nil && UserDefaults.standard.object(forKey: "userId") != nil {
                 let route = try await authUseCase.checkToken()
                 
                 switch route {


### PR DESCRIPTION
## 🎫 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
디플레이 앱을 삭제하고 재설치했을 때, userId가 동기화되지 않아 마이페이지 진입에 오류가 생겼던 현상을 해결했습니다.

## 🎫 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- 앱 진입 시 UserId가 로컬에 저장되어 있는 지 확인하는 로직 추가

  ```
    func start() {
        let vc = SplashViewController()
        rootViewController.setViewControllers([vc], animated: true)
        
        Task { @MainActor in
            try? await Task.sleep(nanoseconds: 1_000_000_000)
            
            if KeychainManager.shared.accessToken != nil && UserDefaults.standard.object(forKey: "userId") != nil {
                let route = try await authUseCase.checkToken()
                
                switch route {
                case .auth:
                    startLoginFlow()
                case .mainTabBar:
                    goToMainTabBar()
                default:
                    break
                }
            } else {
                startLoginFlow()
            }
        }
    }
  ```

## 🎫 Thoughts
<!-- 깊이 고민한 내용을 작성해주세요. -->

기존 로직에서 로그아웃/회원탈퇴 시에는 저장된 UserId를 삭제하여 재로그인 시 다시 할당받는 로직이 있었지만, 앱이 삭제됐을 때 UserDefaults가 초기화되는 상황을 고려하지 못했습니다.
따라서 키체인 재설치 시 키체인 내부에 저장된 토큰으로 자동로그인이 실행되지만 userId를 재할당받지 못하여 마이페이지 진입 시 오류가 발생하는 문제를 확인했습니다.

이를 해결하기 위해서 앱 진입 시 키체인의 access token을 확인하는 과정과 동시에, 로컬 USerDefaults에 userId가 저장되어 있는 지도 함께 확인하여 존재하지 않을 시에 로그인 화면으로 이동시키면서 userId의 일관성이 유지되도록 수정했습니다. 

## 🎫 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능1    |   기능2   |
| :-: | :-: |
| <스크린샷> | <스크린샷> |

## 🎫 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🎫 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #60


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 애플리케이션 시작 시 인증 검증 프로세스가 개선되었습니다. 사용자의 필수 정보가 누락되거나 불완전한 경우, 불필요한 검증을 시도하지 않고 로그인 화면으로 안내하도록 변경되어 더욱 안정적인 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->